### PR TITLE
Init Cohesity Client with auth_token.

### DIFF
--- a/managementsdk/CohesityManagementSdk.go
+++ b/managementsdk/CohesityManagementSdk.go
@@ -113,3 +113,13 @@ func NewCohesitySdkClient(clustervip string, username string, password string, d
 
 	return cohesityManagementSdkClient
 }
+
+//CohesityPatch
+func NewCohesityClientWithToken(clustervip string, mgmtauthtoken *models.AccessToken) COHESITYMANAGEMENTSDK {
+	cohesityManagementSdkClient := new(COHESITYMANAGEMENTSDK_IMPL)
+	cohesityManagementSdkClient.config = configuration.NewCONFIGURATION()
+	cohesityManagementSdkClient.config.SetClusterVip(&clustervip)
+	cohesityManagementSdkClient.config.SetSkipSSL(true)
+	cohesityManagementSdkClient.config.SetAccessToken(mgmtauthtoken)
+	return cohesityManagementSdkClient
+}


### PR DESCRIPTION
Fix for initializing cohesity client with authtoken instead of username
and password.

The user can now initialize the client library with
CohesityManagementSdk.NewCohesityClientWithToken(ClusterVip, mgmtauthtoken)
and also CohesityManagementSdk.NewCohesitySdkClient(ClusterVip, Username, Password, Domain, auth_token, skipSsl)